### PR TITLE
Fix test_model() for datasets with #classes != 10

### DIFF
--- a/src/utils/evaluation.py
+++ b/src/utils/evaluation.py
@@ -24,7 +24,7 @@ def test_model(model: LightningModule, criterion: torch.nn.Module, data_loader: 
 
     accuracy = Accuracy()
     running_loss = 0
-    predictions = np.ndarray((0, 10))
+    predictions = np.ndarray((0, len(data_loader.dataset.classes)))
     targets = np.array([])
 
     with torch.no_grad():


### PR DESCRIPTION
Not the most robust function to determine the number of classes as custom datasets are not required to provide the `.classes` attribute. However, works for the torchvision and ImageFolder datasets